### PR TITLE
Created CLI and Improved Terminal Output

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+async function main( args ) {
+    const { CLI } = await import( '../src/CLI.mjs' );
+    const cli = new CLI();
+    await cli.start();
+    return true
+}
+
+main()
+    .then( a => a )
+    .catch( e => console.log( e ) )

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "localdrive": "1.11.4",
         "socket.io": "^4.7.4"
       },
+      "bin": {
+        "tap": "bin/tap.js"
+      },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node src/main.mjs"
   },
+  "bin": {
+    "tap": "bin/tap.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Trac-Systems/tap-reader.git"

--- a/src/CLI.mjs
+++ b/src/CLI.mjs
@@ -1,0 +1,14 @@
+import TracManager from "./TracManager.mjs";
+
+
+export class CLI {
+    constructor() {}
+
+
+    async start() {
+        let tracCore = new TracManager();
+        await tracCore.initReader();
+
+        return true;
+    }
+}

--- a/src/RestModule.mjs
+++ b/src/RestModule.mjs
@@ -3,6 +3,7 @@ import Fastify from "fastify";
 import TracManager from "./TracManager.mjs";
 import swagger from "@fastify/swagger";
 import fastifySwaggerUi from "@fastify/swagger-ui";
+import { printConsole } from "./helpers/mixed.mjs";
 
 export default class RestModule {
   /**
@@ -3526,7 +3527,13 @@ export default class RestModule {
       const port = config.get("restPort") || 3000; // Defaulting to 3000 if not configured
       await this.fastify.listen({ port });
       // this.fastify.swagger();
-      console.log(`REST server listening on port ${port}`);
+
+      printConsole({ topic: "REST", value: `Listening on port: ${port}` })
+      if( config.get( "enableRestApiDocs" ) ) {
+        printConsole({ topic: "REST", value: `Docs: http://localhost:${port}/docs`})
+      }
+
+      // console.log(`REST server listening on port ${port}`);
     } catch (err) {
       this.fastify.log.error(err);
       process.exit(1);

--- a/src/WebsocketModule.mjs
+++ b/src/WebsocketModule.mjs
@@ -15,7 +15,7 @@ export default class WebsocketModule {
     this.httpServer = createServer();
     this.httpServer.maxConnections = 1000;
 
-    printConsole( { topic: "Websocket", value: `Starting socket.io: http://localhost:${this.socket_port}` } )
+    printConsole( { topic: "Websocket", value: `Starting socket.io on port: ${this.socket_port}` } )
     // console.log("Starting socket.io");
     this.io = new Server(this.httpServer, {
       cors: {

--- a/src/WebsocketModule.mjs
+++ b/src/WebsocketModule.mjs
@@ -1,6 +1,7 @@
 import { createServer } from "http";
 import { Server } from "socket.io";
 import config from "config";
+import { printConsole } from "./helpers/mixed.mjs";
 
 export default class WebsocketModule {
   /**
@@ -14,7 +15,8 @@ export default class WebsocketModule {
     this.httpServer = createServer();
     this.httpServer.maxConnections = 1000;
 
-    console.log("Starting socket.io");
+    printConsole( { topic: "Websocket", value: `Starting socket.io: http://localhost:${this.socket_port}` } )
+    // console.log("Starting socket.io");
     this.io = new Server(this.httpServer, {
       cors: {
         origin: config.get("websocketCORS"),
@@ -768,7 +770,8 @@ export default class WebsocketModule {
           result: result,
         });
 
-        console.log("Served response", response);
+        printConsole( { topic: "Websocket", value: "Served response", secondLineValue: response } )
+        // console.log("Served response", response);
       });
     });
   }

--- a/src/helpers/mixed.mjs
+++ b/src/helpers/mixed.mjs
@@ -1,0 +1,14 @@
+function printConsole( { topic, value, secondLineValue } ) {
+    const space = new Array( 26 - topic.length ).fill( " " ).join( "" )
+
+    console.log( `${topic}${space}${value}` )
+    if( secondLineValue !== undefined ) {
+        const n = new Array( 26 ).fill( " " ).join( "" )
+        console.log( `${n}${secondLineValue}` )
+    }
+
+    return true
+}
+
+
+export { printConsole }


### PR DESCRIPTION
I have created a CLI named "tap" and standardized the output using a helper function `printConsole` located at "./src/helpers/mixed.mjs". Additionally, if `enableRestApiDocs` is marked as `true`, the link to the docs is inserted.

```
  _____                  ____                 ____                _           
 |_   _| __ __ _  ___   / ___|___  _ __ ___  |  _ \ ___  __ _  __| | ___ _ __ 
   | || '__/ _` |/ __| | |   / _ \| '__/ _ \ | |_) / _ \/ _` |/ _` |/ _ \ '__|
   | || | | (_| | (__  | |__| (_) | | |  __/ |  _ <  __/ (_| | (_| |  __/ |   
   |_||_|  \__,_|\___|  \____\___/|_|  \___| |_| \_\___|\__,_|\__,_|\___|_|   
                                                                              
Protocol                  Ordinals/TAP
Channel                   4600e05f4b315ea2ac832aa893aed4872ca0d5e40cf35e22592de55efa460edd
Peer (new Connection)     981af24c81834d201508dae3545165f01072e6c492bbd4e8ff4e9b0f7a8711c3
...
Peer (new Connection)     4fd1faebe2038622faffe0ecce492f77b0bc33aea194d68078f47ec1d4c4c710
Websocket                 Enabled
Websocket                 Starting socket.io on port: 5095
REST                      Enabled
REST                      Listening on port: 5099
REST                      Docs: http://localhost:5099/docs
Peer (new Connection)     4593060bf40eb3fb8c85c11af8d01980e90d9d654bd0d93b545dfb7486613821
Peer (Connection Error)   a508966ab8de929b0908f8fa6aa3b38abc34927677178f401211f2387c1e494f
                          Error: connection timed out
Peer (Connection Closed)  a508966ab8de929b0908f8fa6aa3b38abc34927677178f401211f2387c1e494f
```

This pull request enhances the usability and clarity of the CLI output, making it easier for users to interact with the application and access relevant documentation.